### PR TITLE
fix: correct Snyk action references to use @master

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -65,7 +65,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Set up Snyk CLI
-        uses: snyk/actions/setup@1d730b57b6e0f430d884a538caa90d6d93e0bf15 # v0.4.0
+        uses: snyk/actions/setup@master
 
       - name: Snyk Code test
         run: snyk code test --sarif > snyk-code.sarif || true

--- a/.github/workflows/snyk-security.yml
+++ b/.github/workflows/snyk-security.yml
@@ -36,10 +36,10 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Set up Snyk CLI
-        uses: snyk/actions/setup@1d730b57b6e0f430d884a538caa90d6d93e0bf15 # v0.4.0
+        uses: snyk/actions/setup@master
 
       - name: Run Snyk to check for vulnerabilities
-        uses: snyk/actions/golang@1d730b57b6e0f430d884a538caa90d6d93e0bf15 # v0.4.0
+        uses: snyk/actions/golang@master
         continue-on-error: true # To make sure that SARIF upload gets called
         env:
           SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}


### PR DESCRIPTION
The previously used SHA (1d730b57b6e0f430d884a538caa90d6d93e0bf15) does not exist in the snyk/actions repository, causing workflow failures.

Changed to use @master which is the officially recommended approach per Snyk's documentation:
- https://github.com/snyk/actions
- https://docs.snyk.io/developer-tools/snyk-ci-cd-integrations/github-actions-for-snyk-setup-and-checking-for-vulnerabilities

While @master is not pinned to a specific version, it is the standard and officially supported way to use Snyk GitHub Actions.

Updated both:
- .github/workflows/build.yml
- .github/workflows/snyk-security.yml