### PR TITLE
Implement AWS credential retrieval and fix related issues

### DIFF
--- a/pkg/credentials/aws.go
+++ b/pkg/credentials/aws.go
@@ -1,5 +1,145 @@
 package credentials
 
+import (
+	"bufio"
+	"fmt"
+	"kubectm/pkg/utils"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+// retrieveAWSCredentials retrieves AWS credentials from environment variables
+// or the ~/.aws/credentials file.
 func retrieveAWSCredentials() (*Credential, error) {
-    return nil, nil
+	// Check environment variables first
+	accessKeyID := os.Getenv("AWS_ACCESS_KEY_ID")
+	secretAccessKey := os.Getenv("AWS_SECRET_ACCESS_KEY")
+
+	if accessKeyID != "" && secretAccessKey != "" {
+		details := map[string]string{
+			"AccessKey": accessKeyID,
+			"SecretKey": secretAccessKey,
+		}
+
+		if sessionToken := os.Getenv("AWS_SESSION_TOKEN"); sessionToken != "" {
+			details["SessionToken"] = sessionToken
+		}
+		if region := os.Getenv("AWS_DEFAULT_REGION"); region != "" {
+			details["Region"] = region
+		}
+
+		utils.InfoLogger.Printf("%s AWS credentials found via environment variables: %v", utils.Iso8601Time(), map[string]string{
+			"AccessKey": utils.ObfuscateCredential(accessKeyID),
+			"SecretKey": utils.ObfuscateCredential(secretAccessKey),
+		})
+
+		return &Credential{
+			Provider: "AWS",
+			Details:  details,
+		}, nil
+	}
+
+	// Fall back to ~/.aws/credentials file
+	credentialsFilePath := filepath.Join(os.Getenv("HOME"), ".aws", "credentials")
+	utils.InfoLogger.Printf("%s Looking for AWS credentials file: %s", utils.Iso8601Time(), credentialsFilePath)
+
+	fileContent, err := os.ReadFile(credentialsFilePath)
+	if err != nil {
+		if os.IsNotExist(err) {
+			utils.WarnLogger.Printf("%s AWS credentials file not found: %s", utils.Iso8601Time(), credentialsFilePath)
+			return nil, nil
+		}
+		utils.ErrorLogger.Printf("%s Error reading AWS credentials file: %v", utils.Iso8601Time(), err)
+		return nil, fmt.Errorf("error reading AWS credentials file: %v", err)
+	}
+
+	profile := os.Getenv("AWS_PROFILE")
+	if profile == "" {
+		profile = "default"
+	}
+
+	cred := parseAWSCredentialsFile(fileContent, profile)
+	if cred != nil {
+		return cred, nil
+	}
+
+	utils.WarnLogger.Printf("%s No AWS credentials found for profile %q", utils.Iso8601Time(), profile)
+	return nil, nil
+}
+
+// parseAWSCredentialsFile parses the AWS credentials file content for the given profile.
+// The file follows INI format with sections like [default] or [profile-name].
+func parseAWSCredentialsFile(content []byte, profile string) *Credential {
+	scanner := bufio.NewScanner(strings.NewReader(string(content)))
+	inSection := false
+	sectionHeader := fmt.Sprintf("[%s]", profile)
+
+	var accessKeyID, secretAccessKey, sessionToken, region string
+
+	for scanner.Scan() {
+		line := strings.TrimSpace(scanner.Text())
+
+		// Skip empty lines and comments
+		if line == "" || strings.HasPrefix(line, "#") || strings.HasPrefix(line, ";") {
+			continue
+		}
+
+		if line == sectionHeader {
+			utils.InfoLogger.Printf("%s Entering AWS credentials section: %s", utils.Iso8601Time(), profile)
+			inSection = true
+			continue
+		} else if strings.HasPrefix(line, "[") && strings.HasSuffix(line, "]") {
+			if inSection {
+				// We've reached the next section, stop parsing
+				break
+			}
+			continue
+		}
+
+		if inSection {
+			parts := strings.SplitN(line, "=", 2)
+			if len(parts) != 2 {
+				continue
+			}
+			key := strings.TrimSpace(parts[0])
+			value := strings.TrimSpace(parts[1])
+
+			switch key {
+			case "aws_access_key_id":
+				accessKeyID = value
+			case "aws_secret_access_key":
+				secretAccessKey = value
+			case "aws_session_token":
+				sessionToken = value
+			case "region":
+				region = value
+			}
+		}
+	}
+
+	if accessKeyID == "" || secretAccessKey == "" {
+		return nil
+	}
+
+	details := map[string]string{
+		"AccessKey": accessKeyID,
+		"SecretKey": secretAccessKey,
+	}
+	if sessionToken != "" {
+		details["SessionToken"] = sessionToken
+	}
+	if region != "" {
+		details["Region"] = region
+	}
+
+	utils.InfoLogger.Printf("%s AWS credentials found via credentials file: %v", utils.Iso8601Time(), map[string]string{
+		"AccessKey": utils.ObfuscateCredential(accessKeyID),
+		"SecretKey": utils.ObfuscateCredential(secretAccessKey),
+	})
+
+	return &Credential{
+		Provider: "AWS",
+		Details:  details,
+	}
 }

--- a/pkg/credentials/aws_test.go
+++ b/pkg/credentials/aws_test.go
@@ -1,0 +1,364 @@
+package credentials
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestRetrieveAWSCredentialsFromEnv(t *testing.T) {
+	// Save and clear all AWS env vars
+	origAccessKey := os.Getenv("AWS_ACCESS_KEY_ID")
+	origSecretKey := os.Getenv("AWS_SECRET_ACCESS_KEY")
+	origSessionToken := os.Getenv("AWS_SESSION_TOKEN")
+	origRegion := os.Getenv("AWS_DEFAULT_REGION")
+	origProfile := os.Getenv("AWS_PROFILE")
+	defer func() {
+		os.Setenv("AWS_ACCESS_KEY_ID", origAccessKey)
+		os.Setenv("AWS_SECRET_ACCESS_KEY", origSecretKey)
+		os.Setenv("AWS_SESSION_TOKEN", origSessionToken)
+		os.Setenv("AWS_DEFAULT_REGION", origRegion)
+		os.Setenv("AWS_PROFILE", origProfile)
+	}()
+
+	tests := []struct {
+		name           string
+		accessKey      string
+		secretKey      string
+		sessionToken   string
+		region         string
+		expectNil      bool
+		expectError    bool
+		checkToken     bool
+		checkRegion    bool
+	}{
+		{
+			name:        "both env vars set",
+			accessKey:   "AKIAIOSFODNN7EXAMPLE",
+			secretKey:   "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY",
+			expectNil:   false,
+			expectError: false,
+		},
+		{
+			name:        "with session token and region",
+			accessKey:   "AKIAIOSFODNN7EXAMPLE",
+			secretKey:   "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY",
+			sessionToken: "FwoGZXIvYXdzEBY",
+			region:      "us-east-1",
+			expectNil:   false,
+			expectError: false,
+			checkToken:  true,
+			checkRegion: true,
+		},
+		{
+			name:        "only access key set",
+			accessKey:   "AKIAIOSFODNN7EXAMPLE",
+			secretKey:   "",
+			expectNil:   true,
+			expectError: false,
+		},
+		{
+			name:        "only secret key set",
+			accessKey:   "",
+			secretKey:   "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY",
+			expectNil:   true,
+			expectError: false,
+		},
+		{
+			name:        "neither set",
+			accessKey:   "",
+			secretKey:   "",
+			expectNil:   true,
+			expectError: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Set env vars for this test case
+			os.Setenv("AWS_ACCESS_KEY_ID", tt.accessKey)
+			os.Setenv("AWS_SECRET_ACCESS_KEY", tt.secretKey)
+			os.Setenv("AWS_SESSION_TOKEN", tt.sessionToken)
+			os.Setenv("AWS_DEFAULT_REGION", tt.region)
+
+			// Point HOME to a non-existent dir so file fallback returns nil
+			origHome := os.Getenv("HOME")
+			os.Setenv("HOME", t.TempDir())
+			defer os.Setenv("HOME", origHome)
+
+			cred, err := retrieveAWSCredentials()
+
+			if tt.expectError && err == nil {
+				t.Error("expected error, got nil")
+			}
+			if !tt.expectError && err != nil {
+				t.Errorf("unexpected error: %v", err)
+			}
+
+			if tt.expectNil {
+				if cred != nil {
+					t.Errorf("expected nil credential, got %+v", cred)
+				}
+				return
+			}
+
+			if cred == nil {
+				t.Fatal("expected credential, got nil")
+			}
+			if cred.Provider != "AWS" {
+				t.Errorf("expected provider AWS, got %s", cred.Provider)
+			}
+			if cred.Details["AccessKey"] != tt.accessKey {
+				t.Errorf("expected access key %s, got %s", tt.accessKey, cred.Details["AccessKey"])
+			}
+			if cred.Details["SecretKey"] != tt.secretKey {
+				t.Errorf("expected secret key %s, got %s", tt.secretKey, cred.Details["SecretKey"])
+			}
+			if tt.checkToken {
+				if cred.Details["SessionToken"] != tt.sessionToken {
+					t.Errorf("expected session token %s, got %s", tt.sessionToken, cred.Details["SessionToken"])
+				}
+			}
+			if tt.checkRegion {
+				if cred.Details["Region"] != tt.region {
+					t.Errorf("expected region %s, got %s", tt.region, cred.Details["Region"])
+				}
+			}
+		})
+	}
+}
+
+func TestParseAWSCredentialsFile(t *testing.T) {
+	tests := []struct {
+		name        string
+		content     string
+		profile     string
+		expectNil   bool
+		accessKey   string
+		secretKey   string
+		sessionToken string
+	}{
+		{
+			name: "default profile",
+			content: `[default]
+aws_access_key_id = AKIAIOSFODNN7EXAMPLE
+aws_secret_access_key = wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY
+`,
+			profile:   "default",
+			expectNil: false,
+			accessKey: "AKIAIOSFODNN7EXAMPLE",
+			secretKey: "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY",
+		},
+		{
+			name: "named profile",
+			content: `[default]
+aws_access_key_id = DEFAULT_KEY
+aws_secret_access_key = DEFAULT_SECRET
+
+[production]
+aws_access_key_id = PROD_KEY_EXAMPLE1234
+aws_secret_access_key = PROD_SECRET_EXAMPLE1234567890
+`,
+			profile:   "production",
+			expectNil: false,
+			accessKey: "PROD_KEY_EXAMPLE1234",
+			secretKey: "PROD_SECRET_EXAMPLE1234567890",
+		},
+		{
+			name: "profile with session token",
+			content: `[default]
+aws_access_key_id = AKIAIOSFODNN7EXAMPLE
+aws_secret_access_key = wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY
+aws_session_token = FwoGZXIvYXdzEBYaDH
+`,
+			profile:      "default",
+			expectNil:    false,
+			accessKey:    "AKIAIOSFODNN7EXAMPLE",
+			secretKey:    "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY",
+			sessionToken: "FwoGZXIvYXdzEBYaDH",
+		},
+		{
+			name: "profile not found",
+			content: `[default]
+aws_access_key_id = AKIAIOSFODNN7EXAMPLE
+aws_secret_access_key = wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY
+`,
+			profile:   "nonexistent",
+			expectNil: true,
+		},
+		{
+			name:      "empty file",
+			content:   "",
+			profile:   "default",
+			expectNil: true,
+		},
+		{
+			name: "missing secret key",
+			content: `[default]
+aws_access_key_id = AKIAIOSFODNN7EXAMPLE
+`,
+			profile:   "default",
+			expectNil: true,
+		},
+		{
+			name: "comments and blank lines",
+			content: `# This is a comment
+; This is also a comment
+
+[default]
+aws_access_key_id = AKIAIOSFODNN7EXAMPLE
+# inline comment line
+aws_secret_access_key = wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY
+`,
+			profile:   "default",
+			expectNil: false,
+			accessKey: "AKIAIOSFODNN7EXAMPLE",
+			secretKey: "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY",
+		},
+		{
+			name: "values with spaces around equals",
+			content: `[default]
+aws_access_key_id  =  AKIAIOSFODNN7EXAMPLE
+aws_secret_access_key  =  wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY
+`,
+			profile:   "default",
+			expectNil: false,
+			accessKey: "AKIAIOSFODNN7EXAMPLE",
+			secretKey: "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cred := parseAWSCredentialsFile([]byte(tt.content), tt.profile)
+
+			if tt.expectNil {
+				if cred != nil {
+					t.Errorf("expected nil, got %+v", cred)
+				}
+				return
+			}
+
+			if cred == nil {
+				t.Fatal("expected credential, got nil")
+			}
+			if cred.Provider != "AWS" {
+				t.Errorf("expected provider AWS, got %s", cred.Provider)
+			}
+			if cred.Details["AccessKey"] != tt.accessKey {
+				t.Errorf("expected access key %s, got %s", tt.accessKey, cred.Details["AccessKey"])
+			}
+			if cred.Details["SecretKey"] != tt.secretKey {
+				t.Errorf("expected secret key %s, got %s", tt.secretKey, cred.Details["SecretKey"])
+			}
+			if tt.sessionToken != "" {
+				if cred.Details["SessionToken"] != tt.sessionToken {
+					t.Errorf("expected session token %s, got %s", tt.sessionToken, cred.Details["SessionToken"])
+				}
+			}
+		})
+	}
+}
+
+func TestRetrieveAWSCredentialsFromFile(t *testing.T) {
+	// Clear env vars so file fallback is used
+	origAccessKey := os.Getenv("AWS_ACCESS_KEY_ID")
+	origSecretKey := os.Getenv("AWS_SECRET_ACCESS_KEY")
+	origProfile := os.Getenv("AWS_PROFILE")
+	origHome := os.Getenv("HOME")
+	defer func() {
+		os.Setenv("AWS_ACCESS_KEY_ID", origAccessKey)
+		os.Setenv("AWS_SECRET_ACCESS_KEY", origSecretKey)
+		os.Setenv("AWS_PROFILE", origProfile)
+		os.Setenv("HOME", origHome)
+	}()
+
+	os.Setenv("AWS_ACCESS_KEY_ID", "")
+	os.Setenv("AWS_SECRET_ACCESS_KEY", "")
+	os.Setenv("AWS_PROFILE", "")
+
+	// Create a temp home directory with an AWS credentials file
+	tempDir := t.TempDir()
+	os.Setenv("HOME", tempDir)
+
+	awsDir := filepath.Join(tempDir, ".aws")
+	if err := os.MkdirAll(awsDir, 0700); err != nil {
+		t.Fatalf("failed to create .aws directory: %v", err)
+	}
+
+	credContent := `[default]
+aws_access_key_id = AKIAIOSFODNN7EXAMPLE
+aws_secret_access_key = wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY
+region = us-west-2
+`
+	credFile := filepath.Join(awsDir, "credentials")
+	if err := os.WriteFile(credFile, []byte(credContent), 0600); err != nil {
+		t.Fatalf("failed to write credentials file: %v", err)
+	}
+
+	cred, err := retrieveAWSCredentials()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if cred == nil {
+		t.Fatal("expected credential, got nil")
+	}
+	if cred.Provider != "AWS" {
+		t.Errorf("expected provider AWS, got %s", cred.Provider)
+	}
+	if cred.Details["AccessKey"] != "AKIAIOSFODNN7EXAMPLE" {
+		t.Errorf("expected access key AKIAIOSFODNN7EXAMPLE, got %s", cred.Details["AccessKey"])
+	}
+	if cred.Details["Region"] != "us-west-2" {
+		t.Errorf("expected region us-west-2, got %s", cred.Details["Region"])
+	}
+}
+
+func TestRetrieveAWSCredentialsWithProfile(t *testing.T) {
+	origAccessKey := os.Getenv("AWS_ACCESS_KEY_ID")
+	origSecretKey := os.Getenv("AWS_SECRET_ACCESS_KEY")
+	origProfile := os.Getenv("AWS_PROFILE")
+	origHome := os.Getenv("HOME")
+	defer func() {
+		os.Setenv("AWS_ACCESS_KEY_ID", origAccessKey)
+		os.Setenv("AWS_SECRET_ACCESS_KEY", origSecretKey)
+		os.Setenv("AWS_PROFILE", origProfile)
+		os.Setenv("HOME", origHome)
+	}()
+
+	os.Setenv("AWS_ACCESS_KEY_ID", "")
+	os.Setenv("AWS_SECRET_ACCESS_KEY", "")
+	os.Setenv("AWS_PROFILE", "staging")
+
+	tempDir := t.TempDir()
+	os.Setenv("HOME", tempDir)
+
+	awsDir := filepath.Join(tempDir, ".aws")
+	if err := os.MkdirAll(awsDir, 0700); err != nil {
+		t.Fatalf("failed to create .aws directory: %v", err)
+	}
+
+	credContent := `[default]
+aws_access_key_id = DEFAULT_KEY_1234567890
+aws_secret_access_key = DEFAULT_SECRET_1234567890
+
+[staging]
+aws_access_key_id = STAGING_KEY_1234567890
+aws_secret_access_key = STAGING_SECRET_1234567890
+`
+	credFile := filepath.Join(awsDir, "credentials")
+	if err := os.WriteFile(credFile, []byte(credContent), 0600); err != nil {
+		t.Fatalf("failed to write credentials file: %v", err)
+	}
+
+	cred, err := retrieveAWSCredentials()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if cred == nil {
+		t.Fatal("expected credential, got nil")
+	}
+	if cred.Details["AccessKey"] != "STAGING_KEY_1234567890" {
+		t.Errorf("expected staging access key, got %s", cred.Details["AccessKey"])
+	}
+}

--- a/pkg/credentials/retrieve.go
+++ b/pkg/credentials/retrieve.go
@@ -17,7 +17,7 @@ func RetrieveAll() ([]Credential, error) {
     var credentials []Credential
 
     // Discover AWS credentials
-    awsCreds, err := retrieveAWSCredentials()  // Stub function
+    awsCreds, err := retrieveAWSCredentials()
     if err != nil {
         log.Printf("Error retrieving AWS credentials: %v", err)
     } else if awsCreds != nil {
@@ -79,34 +79,29 @@ func RetrieveSelected(selectedProviders []string) ([]Credential, error) {
     var creds []Credential
 
     for _, provider := range selectedProviders {
+        var cred *Credential
+        var err error
+
         switch provider {
         case "AWS":
-            cred, err := retrieveAWSCredentials()
-            if err != nil {
-                return nil, fmt.Errorf("error retrieving AWS credentials: %v", err)
-            }
-            creds = append(creds, *cred)
+            cred, err = retrieveAWSCredentials()
         case "Azure":
-            cred, err := retrieveAzureCredentials()
-            if err != nil {
-                return nil, fmt.Errorf("error retrieving Azure credentials: %v", err)
-            }
-            creds = append(creds, *cred)
+            cred, err = retrieveAzureCredentials()
         case "GCP":
-            cred, err := retrieveGCPCredentials()
-            if err != nil {
-                return nil, fmt.Errorf("error retrieving GCP credentials: %v", err)
-            }
-            creds = append(creds, *cred)
+            cred, err = retrieveGCPCredentials()
         case "Linode":
-            cred, err := retrieveLinodeCredentials()
-            if err != nil {
-                return nil, fmt.Errorf("error retrieving Linode credentials: %v", err)
-            }
-            creds = append(creds, *cred)
+            cred, err = retrieveLinodeCredentials()
         default:
             return nil, fmt.Errorf("unsupported provider: %s", provider)
         }
+
+        if err != nil {
+            return nil, fmt.Errorf("error retrieving %s credentials: %v", provider, err)
+        }
+        if cred == nil {
+            return nil, fmt.Errorf("%s credentials not found", provider)
+        }
+        creds = append(creds, *cred)
     }
 
     return creds, nil

--- a/pkg/kubeconfig/linode.go
+++ b/pkg/kubeconfig/linode.go
@@ -4,7 +4,7 @@ import (
     "encoding/base64"
     "encoding/json"
     "fmt"
-    "io/ioutil"
+    "io"
     "net/http"
     "os"
     "path/filepath"
@@ -107,7 +107,7 @@ func getLinodeClusters(token string) ([]LinodeCluster, error) {
     // Check the status code of the response.
     if resp.StatusCode != http.StatusOK {
         // If the status code is not 200, read the body and return an error.
-        body, _ := ioutil.ReadAll(resp.Body)
+        body, _ := io.ReadAll(resp.Body)
         return nil, fmt.Errorf("failed to list clusters, status: %d, body: %s", resp.StatusCode, string(body))
     }
 
@@ -153,7 +153,7 @@ func getLinodeKubeconfig(token string, clusterID int) (string, error) {
     // Check the status code of the response.
     if resp.StatusCode != http.StatusOK {
         // If the status code is not 200, read the body and return an error.
-        body, _ := ioutil.ReadAll(resp.Body)
+        body, _ := io.ReadAll(resp.Body)
         return "", fmt.Errorf("failed to retrieve kubeconfig, status: %d, body: %s", resp.StatusCode, string(body))
     }
 

--- a/pkg/utils/logging.go
+++ b/pkg/utils/logging.go
@@ -2,7 +2,7 @@ package utils
 
 import (
     "log"
-    "io/ioutil"
+    "io"
     "os"
     "time"
     "strings"
@@ -10,8 +10,8 @@ import (
 )
 
 func init() {
-    // Disable the default logger by redirecting it to ioutil.Discard
-    log.SetOutput(ioutil.Discard)
+    // Disable the default logger by redirecting it to io.Discard
+    log.SetOutput(io.Discard)
 }
 
 // Loggers for different log levels


### PR DESCRIPTION
- Implement retrieveAWSCredentials() to discover AWS credentials from
  environment variables (AWS_ACCESS_KEY_ID, AWS_SECRET_ACCESS_KEY,
  AWS_SESSION_TOKEN, AWS_DEFAULT_REGION) and fall back to parsing
  ~/.aws/credentials file with AWS_PROFILE support
- Fix nil pointer dereference in RetrieveSelected() that would panic
  when a provider's credential function returns (nil, nil)
- Replace deprecated io/ioutil usage with io package in linode.go
  and logging.go
- Add comprehensive tests for AWS credential retrieval covering
  env vars, file parsing, profile selection, and edge cases

https://claude.ai/code/session_01CFzHXwg1GyLHhDeUUjTNXf