### PR TITLE
Potential fix for code scanning alert no. 18: Uncontrolled data used in path expression

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -140,12 +140,24 @@ func resetStoredCredentials() {
 	if err != nil {
 		errorLogger.Fatalf("%s Failed to get user home directory: %v", iso8601Time(), err)
 	}
-	homeDir = filepath.Clean(homeDir)
-	configFile := filepath.Join(homeDir, storedCredsPath)
-	if !strings.HasPrefix(configFile, homeDir) {
-		errorLogger.Fatalf("%s Invalid credentials path: %s", iso8601Time(), configFile)
+
+	absHomeDir, err := filepath.Abs(filepath.Clean(homeDir))
+	if err != nil {
+		errorLogger.Fatalf("%s Failed to resolve home directory: %v", iso8601Time(), err)
 	}
-	err = os.Remove(configFile)
+
+	configFile := filepath.Join(absHomeDir, storedCredsPath)
+	absConfigFile, err := filepath.Abs(filepath.Clean(configFile))
+	if err != nil {
+		errorLogger.Fatalf("%s Failed to resolve credentials path: %v", iso8601Time(), err)
+	}
+
+	relPath, err := filepath.Rel(absHomeDir, absConfigFile)
+	if err != nil || relPath == ".." || strings.HasPrefix(relPath, ".."+string(filepath.Separator)) {
+		errorLogger.Fatalf("%s Invalid credentials path: %s", iso8601Time(), absConfigFile)
+	}
+
+	err = os.Remove(absConfigFile)
 	if err != nil && !os.IsNotExist(err) {
 		errorLogger.Fatalf("%s Failed to reset stored credentials: %v", iso8601Time(), err)
 	}


### PR DESCRIPTION
Potential fix for [https://github.com/johnybradshaw/kubectm/security/code-scanning/18](https://github.com/johnybradshaw/kubectm/security/code-scanning/18)

Use canonical path validation before deletion: resolve both the base directory and target file to absolute, cleaned paths, then verify the target is inside the base directory using `filepath.Rel` (or equivalent robust check) before calling `os.Remove`.

Best fix in `cmd/main.go` (within `resetStoredCredentials`):
- Keep retrieving `homeDir`.
- Resolve `absHomeDir := filepath.Abs(filepath.Clean(homeDir))`.
- Build candidate path with `filepath.Join(absHomeDir, storedCredsPath)`, then resolve absolute clean target.
- Validate containment via `rel, err := filepath.Rel(absHomeDir, absConfigFile)` and reject if `rel == ".."` or starts with `"../"` (and separator-aware variant).
- Use validated absolute target in `os.Remove`.

No new imports are required (existing `filepath` and `strings` are sufficient).


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
