### PR TITLE
security: confine credential reset to home dir with os.Root (alert #20)

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -157,24 +157,17 @@ func resetStoredCredentials() {
 		errorLogger.Fatalf("%s Failed to get user home directory: %v", iso8601Time(), err)
 	}
 
-	absHomeDir, err := filepath.Abs(filepath.Clean(homeDir))
+	// Confine all path resolution to the home directory with os.Root. Root
+	// operations cannot escape the root (".." and absolute paths are rejected),
+	// which removes the path-traversal concern by construction rather than via
+	// after-the-fact string checks.
+	root, err := os.OpenRoot(homeDir)
 	if err != nil {
-		errorLogger.Fatalf("%s Failed to resolve home directory: %v", iso8601Time(), err)
+		errorLogger.Fatalf("%s Failed to open home directory: %v", iso8601Time(), err)
 	}
+	defer root.Close()
 
-	configFile := filepath.Join(absHomeDir, storedCredsPath)
-	absConfigFile, err := filepath.Abs(filepath.Clean(configFile))
-	if err != nil {
-		errorLogger.Fatalf("%s Failed to resolve credentials path: %v", iso8601Time(), err)
-	}
-
-	relPath, err := filepath.Rel(absHomeDir, absConfigFile)
-	if err != nil || relPath == ".." || strings.HasPrefix(relPath, ".."+string(filepath.Separator)) {
-		errorLogger.Fatalf("%s Invalid credentials path: %s", iso8601Time(), absConfigFile)
-	}
-
-	err = os.Remove(absConfigFile)
-	if err != nil && !os.IsNotExist(err) {
+	if err := root.Remove(filepath.FromSlash(storedCredsPath)); err != nil && !os.IsNotExist(err) {
 		errorLogger.Fatalf("%s Failed to reset stored credentials: %v", iso8601Time(), err)
 	}
 	warnLogger.Printf("%s Stored credentials have been reset. You'll be prompted to select credentials.", iso8601Time())

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -167,7 +167,7 @@ func resetStoredCredentials() {
 	}
 	defer root.Close()
 
-	if err := root.Remove(filepath.FromSlash(storedCredsPath)); err != nil && !os.IsNotExist(err) {
+	if err := root.Remove(storedCredsPath); err != nil && !os.IsNotExist(err) {
 		errorLogger.Fatalf("%s Failed to reset stored credentials: %v", iso8601Time(), err)
 	}
 	warnLogger.Printf("%s Stored credentials have been reset. You'll be prompted to select credentials.", iso8601Time())


### PR DESCRIPTION
Fresh, corrected fix for CodeQL code-scanning alert #20 ("Uncontrolled data used in path expression") in `resetStoredCredentials` — the alternative to autofix #89, which I recommended against because it re-anchored to `os.UserConfigDir()` and would have made `--reset-creds` target the wrong path (`~/.config/kubectm/.kubectm/...`) and silently no-op.

## Approach
Open the home directory as an `os.Root` (Go 1.24+) and remove the stored credentials file through it:

```go
root, err := os.OpenRoot(homeDir)
...
defer root.Close()
if err := root.Remove(filepath.FromSlash(storedCredsPath)); err != nil && !os.IsNotExist(err) { ... }
```

`os.Root` operations are confined to the root and reject `..`/absolute traversal **by construction**, so the path can't escape the home directory — a stronger, idiomatic guarantee than the previous after-the-fact `filepath.Rel` string check, and it's the pattern CodeQL recognises as a sanitizer.

The home directory remains the trust anchor, consistent with where `SaveSelectedCredentialProviders` writes `~/.kubectm/selected_providers.json`, so `--reset-creds` keeps deleting the correct file.

This supersedes #89 (recommend closing that one).

## Verification
- `go build ./cmd` ✅
- `go vet ./...` ✅
- `go test ./...` ✅
- Requires Go ≥ 1.24 for `os.Root`; the module is already on `go 1.26.0`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01EUpQUFiearsC1tSa29h1cD)_