### PR TITLE
Add kubeconfig backup before merge with configurable retention

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -48,6 +48,7 @@ kubectm is a CLI tool that downloads and merges Kubernetes configurations from c
   - `linode.go` - Calls Linode API (`/lke/clusters` and `/lke/clusters/{id}/kubeconfig`) to fetch kubeconfigs
   - `aws.go` - Downloads EKS kubeconfigs: auto-discovers regions via EC2 DescribeRegions, lists/describes EKS clusters in parallel, generates exec-based kubeconfigs using `aws eks get-token`
   - `merge.go` - Merges `.yaml` files from `~/.kube/` into the main config, handles context naming conflicts, adds Aptakube extension for Linode icon
+  - `backup.go` - Backs up `~/.kube/config` to `~/.kube/config.bak.{timestamp}` before merge; prunes old backups (keeps last N, default 5)
   - `rename.go` - Stub for renaming clusters and contexts in kubeconfig files
   - `lke.png` - Embedded Linode icon (via `//go:embed`)
 
@@ -60,7 +61,8 @@ kubectm is a CLI tool that downloads and merges Kubernetes configurations from c
 1. On first run: discover all available credentials → prompt user to select → save selection to `~/.kubectm/selected_providers.json`
 2. On subsequent runs: load saved provider selection → retrieve credentials for those providers
 3. For each provider: download kubeconfigs to `~/.kube/{label}-kubeconfig.yaml`
-4. Merge all `.yaml` files into `~/.kube/config`, then delete the temporary files
+4. Back up the existing `~/.kube/config` to `~/.kube/config.bak.{timestamp}` (keeping the last N backups)
+5. Merge all `.yaml` files into `~/.kube/config`, then delete the temporary files
 
 ### Linode API Integration
 
@@ -103,6 +105,7 @@ Authentication via static credentials from the discovered `Credential.Details` (
 - `-h, --help`: Show help message
 - `-v, --version`: Show version
 - `--reset-creds`: Reset stored credentials and prompt for new ones
+- `--backup-count <n>`: Number of kubeconfig backups to keep (default: 5)
 
 ## Release Process
 

--- a/TODOS.md
+++ b/TODOS.md
@@ -10,6 +10,11 @@
 
 ## Completed
 
+### P1: Backup before merge
+**What:** Back up `~/.kube/config` to `~/.kube/config.bak.{timestamp}` before the merge modifies it, keep the last N backups (configurable via `--backup-count`, default 5), and log the backup path.
+**Why:** A bad merge previously destroyed the existing kubeconfig with no way to recover (PRD §5.3).
+**Completed:** 2026-07-01
+
 ### P1: Implement AWS EKS kubeconfig download
 **What:** Implement full AWS EKS kubeconfig download using the architecture decisions from eng review (2026-03-20).
 **Why:** AWS EKS is the highest-priority missing provider. Credential discovery is done; download pipeline is the remaining gap.

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -42,9 +42,10 @@ func printUsage() {
 Usage: kubectm [options]
 
 Options:
-  -h, --help        Show this help message and exit.
-  -v, --version     Show the version of kubectm.
-  --reset-creds     Reset the stored credentials and prompt for new ones.
+  -h, --help          Show this help message and exit.
+  -v, --version       Show the version of kubectm.
+  --reset-creds       Reset the stored credentials and prompt for new ones.
+  --backup-count <n>  Number of kubeconfig backups to keep (default: 5).
 
 For more information and source code, visit:
 https://github.com/johnybradshaw/kubectm
@@ -219,12 +220,14 @@ func main() {
 	var showHelp bool
 	var showVersion bool
 	var resetCreds bool
+	var backupCount int
 
 	flag.BoolVar(&showHelp, "help", false, "Show help message")
 	flag.BoolVar(&showHelp, "h", false, "Show help message")
 	flag.BoolVar(&showVersion, "version", false, "Show version information")
 	flag.BoolVar(&showVersion, "v", false, "Show version information")
 	flag.BoolVar(&resetCreds, "reset-creds", false, "Reset stored credentials and prompt for new ones")
+	flag.IntVar(&backupCount, "backup-count", kubeconfig.DefaultBackupCount, "Number of kubeconfig backups to keep")
 	flag.Parse()
 
 	if showHelp {
@@ -251,6 +254,12 @@ func main() {
 	}
 
 	downloadAllConfigs(creds)
+
+	// Back up the existing kubeconfig before the merge modifies it, so a bad
+	// merge is always recoverable.
+	if _, err := kubeconfig.BackupConfig(backupCount); err != nil {
+		errorLogger.Fatalf("%s Failed to back up kubeconfig: %v", iso8601Time(), err)
+	}
 
 	if err := kubeconfig.MergeConfigs(); err != nil {
 		errorLogger.Fatalf("%s Failed to merge kubeconfig files: %v", iso8601Time(), err)

--- a/docs/PRD.md
+++ b/docs/PRD.md
@@ -41,6 +41,7 @@ Run `kubectm` once and your kubeconfig is current across every provider.
 | Cross-platform builds | Done | Linux/macOS/Windows x amd64/arm64, GPG signed, attested |
 | Path traversal protection | Done | File operations validated within `~/.kube/` |
 | Credential obfuscation | Done | Sensitive values masked in log output |
+| Backup before merge | Done | `~/.kube/config` copied to `config.bak.{timestamp}` before merge; last N kept (`--backup-count`, default 5) |
 
 ### What's Stubbed or Missing
 
@@ -53,7 +54,6 @@ Run `kubectm` once and your kubeconfig is current across every provider.
 | GCP kubeconfig download | Not started | — |
 | Context/cluster renaming | Stub | `RenameConfigs()` logs and returns nil |
 | Dry-run mode | Not started | No way to preview without modifying config |
-| Backup before merge | Not started | No backup of existing `~/.kube/config` |
 
 ## 4. Target Providers
 

--- a/pkg/kubeconfig/CLAUDE.md
+++ b/pkg/kubeconfig/CLAUDE.md
@@ -12,10 +12,12 @@ Downloads kubeconfigs from cloud provider APIs and merges them into `~/.kube/con
 | `linode.go` | Calls Linode API v4 to fetch LKE cluster kubeconfigs |
 | `aws.go` | Downloads EKS kubeconfigs via AWS SDK v2 (EC2 DescribeRegions, EKS ListClusters/DescribeCluster) with parallel region scanning, exec-based auth, and optional config override |
 | `merge.go` | Merges `.yaml` files from `~/.kube/` into main config |
+| `backup.go` | Backs up `~/.kube/config` to `config.bak.{timestamp}` before merge; prunes old backups keeping the most recent N (default 5) |
 | `rename.go` | Stub for renaming clusters/contexts in kubeconfigs |
 | `lke.png` | Embedded Linode icon for Aptakube extension (`//go:embed`) |
 | `linode_test.go` | Tests for Linode kubeconfig download |
 | `aws_test.go` | Tests for AWS EKS kubeconfig download (13 cases with httptest mock servers) |
+| `backup_test.go` | Tests for kubeconfig backup and pruning |
 
 ## Dependencies
 

--- a/pkg/kubeconfig/backup.go
+++ b/pkg/kubeconfig/backup.go
@@ -1,0 +1,109 @@
+package kubeconfig
+
+import (
+    "fmt"
+    "os"
+    "path/filepath"
+    "sort"
+    "strings"
+    "time"
+    "kubectm/pkg/utils"
+)
+
+// DefaultBackupCount is the default number of kubeconfig backups to keep.
+const DefaultBackupCount = 5
+
+// backupPrefix is the filename prefix used for kubeconfig backups in ~/.kube/.
+const backupPrefix = "config.bak."
+
+// BackupConfig copies ~/.kube/config to ~/.kube/config.bak.{timestamp} so the
+// user can recover the previous state if a merge goes wrong. After creating
+// the backup it prunes older backups, keeping only the most recent `keep`
+// files (values below 1 are treated as 1).
+//
+// It returns the path of the created backup, or an empty string if there was
+// no existing kubeconfig to back up.
+func BackupConfig(keep int) (string, error) {
+    homeDir, kubeDir, err := getKubeDir()
+    if err != nil {
+        return "", err
+    }
+
+    if !strings.HasPrefix(kubeDir, homeDir) {
+        return "", fmt.Errorf("invalid kubeconfig directory outside user home: %s", kubeDir)
+    }
+
+    configPath := filepath.Clean(filepath.Join(kubeDir, "config"))
+    if !strings.HasPrefix(configPath, kubeDir) {
+        return "", fmt.Errorf("invalid main kubeconfig path outside .kube directory: %s", configPath)
+    }
+
+    data, err := os.ReadFile(configPath)
+    if err != nil {
+        if os.IsNotExist(err) {
+            utils.InfoLogger.Printf("%s No existing kubeconfig at %s, skipping backup", utils.Iso8601Time(), configPath)
+            return "", nil
+        }
+        return "", fmt.Errorf("failed to read kubeconfig for backup: %v", err)
+    }
+
+    // Compact ISO 8601 (no colons) so the filename is valid on Windows too.
+    timestamp := time.Now().UTC().Format("20060102T150405Z")
+    backupPath := filepath.Clean(filepath.Join(kubeDir, backupPrefix+timestamp))
+    if !strings.HasPrefix(backupPath, kubeDir) {
+        return "", fmt.Errorf("invalid backup path outside .kube directory: %s", backupPath)
+    }
+
+    if err := os.WriteFile(backupPath, data, 0600); err != nil {
+        return "", fmt.Errorf("failed to write kubeconfig backup: %v", err)
+    }
+    utils.InfoLogger.Printf("%s Backed up kubeconfig to %s", utils.Iso8601Time(), backupPath)
+
+    if err := pruneBackups(kubeDir, keep); err != nil {
+        utils.WarnLogger.Printf("%s Warning: failed to prune old kubeconfig backups: %v", utils.Iso8601Time(), err)
+    }
+
+    return backupPath, nil
+}
+
+// pruneBackups removes the oldest config.bak.* files in kubeDir, keeping the
+// most recent `keep` backups. Backup filenames embed a compact ISO 8601 UTC
+// timestamp, so lexical order matches chronological order.
+func pruneBackups(kubeDir string, keep int) error {
+    if keep < 1 {
+        keep = 1
+    }
+
+    entries, err := os.ReadDir(kubeDir)
+    if err != nil {
+        return fmt.Errorf("failed to read kubeconfig directory: %v", err)
+    }
+
+    var backups []string
+    for _, entry := range entries {
+        if entry.IsDir() || !strings.HasPrefix(entry.Name(), backupPrefix) {
+            continue
+        }
+        backups = append(backups, entry.Name())
+    }
+
+    if len(backups) <= keep {
+        return nil
+    }
+
+    sort.Strings(backups)
+    for _, name := range backups[:len(backups)-keep] {
+        backupPath := filepath.Clean(filepath.Join(kubeDir, name))
+        if !strings.HasPrefix(backupPath, kubeDir) {
+            utils.WarnLogger.Printf("%s Skipping deletion of file outside .kube directory: %s", utils.Iso8601Time(), backupPath)
+            continue
+        }
+        if err := os.Remove(backupPath); err != nil {
+            utils.WarnLogger.Printf("%s Warning: failed to delete old backup %s: %v", utils.Iso8601Time(), backupPath, err)
+        } else {
+            utils.InfoLogger.Printf("%s Deleted old kubeconfig backup %s", utils.Iso8601Time(), backupPath)
+        }
+    }
+
+    return nil
+}

--- a/pkg/kubeconfig/backup.go
+++ b/pkg/kubeconfig/backup.go
@@ -16,6 +16,10 @@ const DefaultBackupCount = 5
 // backupPrefix is the filename prefix used for kubeconfig backups in ~/.kube/.
 const backupPrefix = "config.bak."
 
+// backupTimestampFormat is the compact ISO 8601 layout used in backup
+// filenames (no colons, so the name is valid on Windows too).
+const backupTimestampFormat = "20060102T150405Z"
+
 // BackupConfig copies ~/.kube/config to ~/.kube/config.bak.{timestamp} so the
 // user can recover the previous state if a merge goes wrong. After creating
 // the backup it prunes older backups, keeping only the most recent `keep`
@@ -29,7 +33,7 @@ func BackupConfig(keep int) (string, error) {
         return "", err
     }
 
-    if !strings.HasPrefix(kubeDir, homeDir) {
+    if rel, relErr := filepath.Rel(homeDir, kubeDir); relErr != nil || rel == ".." || strings.HasPrefix(rel, ".."+string(filepath.Separator)) {
         return "", fmt.Errorf("invalid kubeconfig directory outside user home: %s", kubeDir)
     }
 
@@ -47,8 +51,7 @@ func BackupConfig(keep int) (string, error) {
         return "", fmt.Errorf("failed to read kubeconfig for backup: %v", err)
     }
 
-    // Compact ISO 8601 (no colons) so the filename is valid on Windows too.
-    timestamp := time.Now().UTC().Format("20060102T150405Z")
+    timestamp := time.Now().UTC().Format(backupTimestampFormat)
     backupPath := filepath.Clean(filepath.Join(kubeDir, backupPrefix+timestamp))
     if !strings.HasPrefix(backupPath, kubeDir) {
         return "", fmt.Errorf("invalid backup path outside .kube directory: %s", backupPath)
@@ -82,6 +85,12 @@ func pruneBackups(kubeDir string, keep int) error {
     var backups []string
     for _, entry := range entries {
         if entry.IsDir() || !strings.HasPrefix(entry.Name(), backupPrefix) {
+            continue
+        }
+        // Only prune files whose suffix is a timestamp we generated, so
+        // manually created backups like config.bak.before-upgrade survive.
+        timestampPart := strings.TrimPrefix(entry.Name(), backupPrefix)
+        if _, err := time.Parse(backupTimestampFormat, timestampPart); err != nil {
             continue
         }
         backups = append(backups, entry.Name())

--- a/pkg/kubeconfig/backup_test.go
+++ b/pkg/kubeconfig/backup_test.go
@@ -1,0 +1,186 @@
+package kubeconfig
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+const testKubeconfigContent = `apiVersion: v1
+kind: Config
+clusters: []
+contexts: []
+users: []
+`
+
+// setupBackupTestHome creates a temp home with a ~/.kube directory and
+// returns the .kube dir path.
+func setupBackupTestHome(t *testing.T) string {
+	t.Helper()
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	kubeDir := filepath.Join(home, ".kube")
+	if err := os.MkdirAll(kubeDir, 0700); err != nil {
+		t.Fatalf("failed to create .kube dir: %v", err)
+	}
+	return kubeDir
+}
+
+// writeTestConfig writes a kubeconfig file at ~/.kube/config.
+func writeTestConfig(t *testing.T, kubeDir string) {
+	t.Helper()
+	if err := os.WriteFile(filepath.Join(kubeDir, "config"), []byte(testKubeconfigContent), 0600); err != nil {
+		t.Fatalf("failed to write test config: %v", err)
+	}
+}
+
+// listBackups returns the names of config.bak.* files in kubeDir, sorted by ReadDir.
+func listBackups(t *testing.T, kubeDir string) []string {
+	t.Helper()
+	entries, err := os.ReadDir(kubeDir)
+	if err != nil {
+		t.Fatalf("failed to read kube dir: %v", err)
+	}
+	var backups []string
+	for _, entry := range entries {
+		if strings.HasPrefix(entry.Name(), backupPrefix) {
+			backups = append(backups, entry.Name())
+		}
+	}
+	return backups
+}
+
+// TestBackupConfigNoExistingConfig verifies that no backup is created and no
+// error is returned when there is no kubeconfig to back up.
+func TestBackupConfigNoExistingConfig(t *testing.T) {
+	kubeDir := setupBackupTestHome(t)
+
+	backupPath, err := BackupConfig(DefaultBackupCount)
+	if err != nil {
+		t.Fatalf("BackupConfig() error = %v", err)
+	}
+	if backupPath != "" {
+		t.Errorf("expected empty backup path, got %q", backupPath)
+	}
+	if backups := listBackups(t, kubeDir); len(backups) != 0 {
+		t.Errorf("expected no backup files, got %v", backups)
+	}
+}
+
+// TestBackupConfigCreatesBackup verifies that the existing kubeconfig is
+// copied to a timestamped backup file with matching content.
+func TestBackupConfigCreatesBackup(t *testing.T) {
+	kubeDir := setupBackupTestHome(t)
+	writeTestConfig(t, kubeDir)
+
+	backupPath, err := BackupConfig(DefaultBackupCount)
+	if err != nil {
+		t.Fatalf("BackupConfig() error = %v", err)
+	}
+	if backupPath == "" {
+		t.Fatal("expected a backup path, got empty string")
+	}
+	if !strings.HasPrefix(filepath.Base(backupPath), backupPrefix) {
+		t.Errorf("expected backup filename to start with %q, got %q", backupPrefix, filepath.Base(backupPath))
+	}
+
+	data, err := os.ReadFile(backupPath)
+	if err != nil {
+		t.Fatalf("failed to read backup file: %v", err)
+	}
+	if string(data) != testKubeconfigContent {
+		t.Errorf("backup content mismatch: got %q, want %q", string(data), testKubeconfigContent)
+	}
+
+	info, err := os.Stat(backupPath)
+	if err != nil {
+		t.Fatalf("failed to stat backup file: %v", err)
+	}
+	if info.Mode().Perm() != 0600 {
+		t.Errorf("expected backup permissions 0600, got %v", info.Mode().Perm())
+	}
+}
+
+// TestBackupConfigPrunesOldBackups verifies that only the most recent `keep`
+// backups survive and that the oldest are deleted.
+func TestBackupConfigPrunesOldBackups(t *testing.T) {
+	kubeDir := setupBackupTestHome(t)
+	writeTestConfig(t, kubeDir)
+
+	// Pre-existing backups with timestamps guaranteed older than the one
+	// BackupConfig is about to create.
+	oldBackups := []string{
+		"config.bak.20200101T000000Z",
+		"config.bak.20200102T000000Z",
+		"config.bak.20200103T000000Z",
+		"config.bak.20200104T000000Z",
+		"config.bak.20200105T000000Z",
+	}
+	for _, name := range oldBackups {
+		if err := os.WriteFile(filepath.Join(kubeDir, name), []byte("old"), 0600); err != nil {
+			t.Fatalf("failed to create old backup %s: %v", name, err)
+		}
+	}
+
+	if _, err := BackupConfig(3); err != nil {
+		t.Fatalf("BackupConfig() error = %v", err)
+	}
+
+	backups := listBackups(t, kubeDir)
+	if len(backups) != 3 {
+		t.Fatalf("expected 3 backups after pruning, got %d: %v", len(backups), backups)
+	}
+	for _, name := range backups {
+		if name == "config.bak.20200101T000000Z" || name == "config.bak.20200102T000000Z" || name == "config.bak.20200103T000000Z" {
+			t.Errorf("expected oldest backup %s to be pruned", name)
+		}
+	}
+}
+
+// TestBackupConfigKeepClampedToOne verifies that keep values below 1 still
+// retain the newly created backup.
+func TestBackupConfigKeepClampedToOne(t *testing.T) {
+	kubeDir := setupBackupTestHome(t)
+	writeTestConfig(t, kubeDir)
+
+	if err := os.WriteFile(filepath.Join(kubeDir, "config.bak.20200101T000000Z"), []byte("old"), 0600); err != nil {
+		t.Fatalf("failed to create old backup: %v", err)
+	}
+
+	backupPath, err := BackupConfig(0)
+	if err != nil {
+		t.Fatalf("BackupConfig() error = %v", err)
+	}
+
+	backups := listBackups(t, kubeDir)
+	if len(backups) != 1 {
+		t.Fatalf("expected exactly 1 backup, got %d: %v", len(backups), backups)
+	}
+	if backups[0] != filepath.Base(backupPath) {
+		t.Errorf("expected surviving backup to be %s, got %s", filepath.Base(backupPath), backups[0])
+	}
+}
+
+// TestBackupConfigLeavesOtherFilesAlone verifies pruning only touches
+// config.bak.* files, not the main config or temporary kubeconfig files.
+func TestBackupConfigLeavesOtherFilesAlone(t *testing.T) {
+	kubeDir := setupBackupTestHome(t)
+	writeTestConfig(t, kubeDir)
+
+	otherFile := filepath.Join(kubeDir, "my-cluster-kubeconfig.yaml")
+	if err := os.WriteFile(otherFile, []byte("temp kubeconfig"), 0600); err != nil {
+		t.Fatalf("failed to create temp kubeconfig: %v", err)
+	}
+
+	if _, err := BackupConfig(1); err != nil {
+		t.Fatalf("BackupConfig() error = %v", err)
+	}
+
+	if _, err := os.Stat(filepath.Join(kubeDir, "config")); err != nil {
+		t.Errorf("expected main config to be untouched: %v", err)
+	}
+	if _, err := os.Stat(otherFile); err != nil {
+		t.Errorf("expected temporary kubeconfig to be untouched: %v", err)
+	}
+}

--- a/pkg/kubeconfig/backup_test.go
+++ b/pkg/kubeconfig/backup_test.go
@@ -163,7 +163,8 @@ func TestBackupConfigKeepClampedToOne(t *testing.T) {
 }
 
 // TestBackupConfigLeavesOtherFilesAlone verifies pruning only touches
-// config.bak.* files, not the main config or temporary kubeconfig files.
+// timestamped config.bak.* files, not the main config, temporary kubeconfig
+// files, or manually created backups without a valid timestamp suffix.
 func TestBackupConfigLeavesOtherFilesAlone(t *testing.T) {
 	kubeDir := setupBackupTestHome(t)
 	writeTestConfig(t, kubeDir)
@@ -171,6 +172,11 @@ func TestBackupConfigLeavesOtherFilesAlone(t *testing.T) {
 	otherFile := filepath.Join(kubeDir, "my-cluster-kubeconfig.yaml")
 	if err := os.WriteFile(otherFile, []byte("temp kubeconfig"), 0600); err != nil {
 		t.Fatalf("failed to create temp kubeconfig: %v", err)
+	}
+
+	manualBackup := filepath.Join(kubeDir, "config.bak.manual")
+	if err := os.WriteFile(manualBackup, []byte("manual backup"), 0600); err != nil {
+		t.Fatalf("failed to create manual backup: %v", err)
 	}
 
 	if _, err := BackupConfig(1); err != nil {
@@ -182,5 +188,8 @@ func TestBackupConfigLeavesOtherFilesAlone(t *testing.T) {
 	}
 	if _, err := os.Stat(otherFile); err != nil {
 		t.Errorf("expected temporary kubeconfig to be untouched: %v", err)
+	}
+	if _, err := os.Stat(manualBackup); err != nil {
+		t.Errorf("expected manual backup to be untouched: %v", err)
 	}
 }


### PR DESCRIPTION
## Summary

Implements the P1 **Backup Before Merge** item from `docs/PRD.md` §5.3 — previously a bad merge could destroy the existing `~/.kube/config` with no way to recover.

- New `pkg/kubeconfig/backup.go`: `BackupConfig(keep int)` copies `~/.kube/config` to `~/.kube/config.bak.{timestamp}` (compact ISO 8601 UTC, filesystem-safe on Windows) and logs the backup path so users can recover.
- After creating a backup it prunes older `config.bak.*` files, keeping only the most recent N (values below 1 are clamped to 1).
- New `--backup-count <n>` CLI flag (default 5) to configure retention; help text updated.
- `main` runs the backup after downloads and before `MergeConfigs()`, and treats a backup failure as fatal so the config is never modified without a recovery point. A missing kubeconfig (first run) skips the backup silently.
- Follows existing package conventions: path traversal checks confined to `~/.kube/`, `utils.*Logger` with ISO 8601 timestamps, 0600 file permissions.
- Docs updated: `CLAUDE.md`, `pkg/kubeconfig/CLAUDE.md`, PRD current-state table, and `TODOS.md`.

## Testing

- `go vet ./...` clean
- `go test -race ./...` passes, including 5 new tests in `pkg/kubeconfig/backup_test.go` covering: no existing config (skip), backup creation with content/permission checks, pruning oldest backups, retention clamping, and leaving non-backup files untouched
- Smoke-tested the built binary: `--help` shows the new flag

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RZU8XJngqjMst65KibTQHv

---
_Generated by [Claude Code](https://claude.ai/code/session_01RZU8XJngqjMst65KibTQHv)_